### PR TITLE
GW2.NET moved to Github and Awesomium was missing on first compilation

### DIFF
--- a/GW2PAO/App.xaml.cs
+++ b/GW2PAO/App.xaml.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using Awesomium.Core;
 using GW2PAO.Infrastructure;
 using GW2PAO.Utility;
 using Hardcodet.Wpf.TaskbarNotification;

--- a/GW2PAO/GW2PAO.csproj
+++ b/GW2PAO/GW2PAO.csproj
@@ -103,8 +103,14 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Awesomium.Core, Version=1.7.5.1, Culture=neutral, PublicKeyToken=e1a0d7c8071a5214, processorArchitecture=x86" />
-    <Reference Include="Awesomium.Windows.Controls, Version=1.7.5.1, Culture=neutral, PublicKeyToken=7a34e179b8b61c39, processorArchitecture=x86" />
+    <Reference Include="Awesomium.Core, Version=1.7.4.2, Culture=neutral, PublicKeyToken=e1a0d7c8071a5214, processorArchitecture=x86">
+      <HintPath>..\packages\Unofficial.Awesomium.Complete.1.7.4.2\lib\Awesomium.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Awesomium.Windows.Controls, Version=1.7.4.2, Culture=neutral, PublicKeyToken=7a34e179b8b61c39, processorArchitecture=x86">
+      <HintPath>..\packages\Unofficial.Awesomium.Complete.1.7.4.2\lib\Awesomium.Windows.Controls.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="FileDb, Version=5.0.1.0, Culture=neutral, PublicKeyToken=ba3f58a0e60cd01d, processorArchitecture=MSIL">
       <HintPath>..\packages\XAML.MapControl.2.5.1\lib\net45\FileDb.dll</HintPath>
       <Private>True</Private>

--- a/GW2PAO/ViewModels/AboutViewModel.cs
+++ b/GW2PAO/ViewModels/AboutViewModel.cs
@@ -96,11 +96,11 @@ namespace GW2PAO.ViewModels
         }
 
         /// <summary>
-        /// Opens the GW2.NET page (https://gw2dotnet.codeplex.com/) using the default browser
+        /// Opens the GW2.NET page (https://github.com/Ruhrpottpatriot/GW2.NET) using the default browser
         /// </summary>
         private void OpenGW2NetPage()
         {
-            Process.Start("https://gw2dotnet.codeplex.com/");
+            Process.Start("https://github.com/Ruhrpottpatriot/GW2.NET");
         }
     }
 }

--- a/GW2PAO/packages.config
+++ b/GW2PAO/packages.config
@@ -18,5 +18,6 @@
   <package id="Prism.MEFExtensions" version="5.0.0" targetFramework="net452" />
   <package id="Prism.Mvvm" version="1.1.1" targetFramework="net452" />
   <package id="Prism.PubSubEvents" version="1.1.2" targetFramework="net452" />
+  <package id="Unofficial.Awesomium.Complete" version="1.7.4.2" targetFramework="net452" />
   <package id="XAML.MapControl" version="2.5.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Hi,

GW2.NET moved to Github. I've updated the url.

I've also noticed that Awesomium is preventing compilation on first checkout. I've added awesomium from an unofficial nuget package to ease compilation.